### PR TITLE
Change default recursive flag to false when purging files.

### DIFF
--- a/src/StackPath/StackPath.php
+++ b/src/StackPath/StackPath.php
@@ -106,7 +106,7 @@ class StackPath
         $files = [];
 
         $opts = array_merge([
-          "recursive" => true,
+          "recursive" => false,
         ], $opts);
 
         foreach ($fileList as $file) {


### PR DESCRIPTION
I had a chat with someone in Stackpath and it seems the recursive=true is causing issues with the processing speed. It also will result in slower processing of the purges requested by the purge_files function. So the recursive parameter should be used only when it is really needed.